### PR TITLE
Ignore dist dir when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,10 @@
     "standard": "^8.6.0",
     "tape": "^4.6.3",
     "watchify": "^3.9.0"
+  },
+  "standard": {
+    "ignore": [
+      "dist/"
+    ]
   }
 }


### PR DESCRIPTION
I happened to notice that the build is currently failing due to the `dist/`
directory not being ignored when running `standard`.

Happy to change the approach to use a whitelist instead of an ignore list. This could be achieved by running `standard *.js test/**/*.js`. 