### PR TITLE
Inline background colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,24 +265,36 @@ function lpad (str, width) {
 }
 
 /**
- * Wrap string with ANSI sequence for red.
- *
- * @param {string} str String to wrap
- * @return {string}
+ * Compose (B combinator).
  */
-function red (str) {
-  return '\x1B[31m' + str + '\x1B[0m'
+function B (f, g) {
+  return function (x) {
+    return f(g(x))
+  }
 }
 
 /**
- * Wrap string with ANSI sequence for green.
+ * Create a colorize function.
  *
- * @param {string} str String to wrap
- * @return {string}
+ * @param {number} code ANSI color code
+ * @return {function}
  */
-function green (str) {
-  return '\x1B[32m' + str + '\x1B[0m'
+function color (code) {
+  /**
+   * Wrap string with ANSI sequence for given color code.
+   *
+   * @param {string} str String to wrap
+   * @return {string}
+   */
+  return function (str) {
+    return '\x1B[' + code + 'm' + str + '\x1B[0m'
+  }
 }
+
+var red = color(31)
+var green = color(32)
+var redBg = B(color(41), color(37))
+var greenBg = B(color(42), color(30))
 
 /**
  * Identity function.
@@ -389,8 +401,8 @@ module.exports = function jasmineDiffMatchers (j$, options) {
     inline: options && options.inline === true,
     spaces: 2
   }
-  var annotateAdd = opts.colors ? green : identity
-  var annotateRemove = opts.colors ? red : identity
+  var annotateAdd = opts.colors ? (opts.inline ? greenBg : green) : identity
+  var annotateRemove = opts.colors ? (opts.inline ? redBg : red) : identity
   var errorDiff = opts.inline ? inlineDiff : unifiedDiff
   var stringify = createStringifier(j$.pp, opts.spaces)
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "test:unit": "nyc tape test/unit/*.test.js",
     "test:functional": "tape test/functional",
     "test": "npm run test:unit && npm run test:functional",
-    "validate": "npm test && npm run coveralls"
+    "validate": "npm test && npm run coveralls",
+    "update-fixture1": "karma start test/functional/karma.conf.js > test/functional/fixtures/karma.conf.js.output || exit 0",
+    "update-fixture2": "karma start test/functional/karma.conf.inline.js > test/functional/fixtures/karma.conf.inline.js.output || exit 0",
+    "update-fixture3": "karma start test/functional/karma.conf.colors.js > test/functional/fixtures/karma.conf.colors.js.output || exit 0",
+    "update-fixtures": "npm run update-fixture1 && npm run update-fixture2 && npm run update-fixture3"
   },
   "homepage": "https://github.com/jimf/jasmine-diff",
   "repository": {

--- a/test/functional/fixtures/karma.conf.colors.js.output
+++ b/test/functional/fixtures/karma.conf.colors.js.output
@@ -1,0 +1,15 @@
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should show diff with colors FAILED
+	Expected object to have properties
+	    baz: 'baz'
+	Expected object not to have properties
+	    bar: 'bar'
+	
+	[32m+ expected[0m
+	[31m- actual[0m
+	
+	[31m-  'bar': 'bar'[0m
+	[32m+  'baz': 'baz'[0m
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure_colored.js:12:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/d2ab8711400d415d82fff1b0b8ee14d1.browserify:2291:49
+	loaded@http://localhost:9876/context.js:162:17
+PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 1 of 1 (1 FAILED) ERROR (0.009 secs / 0.007 secs)

--- a/test/functional/fixtures/karma.conf.inline.js.output
+++ b/test/functional/fixtures/karma.conf.inline.js.output
@@ -1,0 +1,25 @@
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should show inline diff with colors FAILED
+	Expected $.bar = 'bar' to equal 'baz'.
+	
+	[41m[37mactual[0m[0m [42m[30mexpected[0m[0m
+	
+	{
+	  'bar': '[41m[37mbar[0m[0m[42m[30mbaz[0m[0m'
+	  'foo': 'foo'
+	}
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure_inline.js:12:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/ed2f426bd5eee6ce9d7ff9abaeb0afe6.browserify:2291:49
+	loaded@http://localhost:9876/context.js:162:17
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should include line numbers when diff exceeds 4 lines FAILED
+	Expected $.baz = 'qux' to equal 'baz'.
+	
+	[41m[37mactual[0m[0m [42m[30mexpected[0m[0m
+	
+	1 | {
+	2 |   'bar': 'bar'
+	3 |   'baz': '[41m[37mqux[0m[0m[42m[30mbaz[0m[0m'
+	4 |   'foo': 'foo'
+	5 | }
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure_inline.js:16:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/ed2f426bd5eee6ce9d7ff9abaeb0afe6.browserify:2295:61
+PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 2 of 2 (2 FAILED) ERROR (0.011 secs / 0.007 secs)

--- a/test/functional/fixtures/karma.conf.js.output
+++ b/test/functional/fixtures/karma.conf.js.output
@@ -1,0 +1,243 @@
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should omit diff when comparing null/undefined FAILED
+	Expected null to be undefined.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:12:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2291:24
+	loaded@http://localhost:9876/context.js:162:17
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should omit diff when comparing scalars FAILED
+	Expected 42 to be true.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:15:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2294:22
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should show diff when comparing long strings FAILED
+	Expected 'The quick brown fox jumped over the lazy dog' to be 'The quick black cat hissed at the lazy dog'.
+	
+	+ expected
+	- actual
+	
+	-The quick brown fox jumped over the lazy dog
+	+The quick black cat hissed at the lazy dog
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:18:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2297:66
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should show diff when comparing multiline strings FAILED
+	Expected 'The quick brown fox
+	jumped over the lazy dog' to be 'The quick black cat
+	hissed at the lazy dog'.
+	
+	+ expected
+	- actual
+	
+	-The quick brown fox
+	-jumped over the lazy dog
+	+The quick black cat
+	+hissed at the lazy dog
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:23:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2302:67
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should show diff when comparing arrays FAILED
+	Expected [ 1, 2, 3 ] to be [ 1, 2, 3, 4 ].
+	
+	+ expected
+	- actual
+	
+	+  4
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:28:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2307:29
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should show diff when comparing objects FAILED
+	Expected Object({ foo: 'foo', bar: 'bar' }) to be Object({ foo: 'foo', baz: 'baz' }).
+	
+	+ expected
+	- actual
+	
+	-  'bar': 'bar'
+	+  'baz': 'baz'
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:31:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2310:46
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toBe should format values FAILED
+	Expected Object({  }) to be Object({ a: null, b: undefined, c: 1, d: -1, e: 'a', f: Function, g: /[aeiou]/, h: [  ], i: [ 1, 2, 3 ], j: [ [ 1 ], [ 2, 3 ] ], k: Object({  }), l: Object({ a: 1, b: 2, c: 3 }), m: Object({ a: Object({ b: Object({ c: 1 }) }) }), n: Object({ a: [ Object({ b: true }) ] }) }).
+	
+	+ expected
+	- actual
+	
+	-{}
+	+{
+	+  'a': null
+	+  'b': undefined
+	+  'c': 1
+	+  'd': -1
+	+  'e': 'a'
+	+  'f': Function
+	+  'g': /[aeiou]/
+	+  'h': []
+	+  'i': [
+	+    1
+	+    2
+	+    3
+	+  ]
+	+  'j': [
+	+    [
+	+      1
+	+    ]
+	+    [
+	+      2
+	+      3
+	+    ]
+	+  ]
+	+  'k': {}
+	+  'l': {
+	+    'a': 1
+	+    'b': 2
+	+    'c': 3
+	+  }
+	+  'm': {
+	+    'a': {
+	+      'b': {
+	+        'c': 1
+	+      }
+	+    }
+	+  }
+	+  'n': {
+	+    'a': [
+	+      {
+	+        'b': true
+	+      }
+	+    ]
+	+  }
+	+}
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:51:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2330:26
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers not.toBe should omit diff when comparing null/undefined FAILED
+	Expected null not to be null.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:57:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2336:28
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers not.toBe should omit diff when comparing scalars FAILED
+	Expected 42 not to be 42.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:60:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2339:26
+..
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should omit diff when comparing null/undefined FAILED
+	Expected null to equal undefined.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:72:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2351:27
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should omit diff when comparing scalars FAILED
+	Expected 42 to equal true.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:75:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2354:25
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should show diff when comparing long strings FAILED
+	Expected 'The quick brown fox jumped over the lazy dog' to equal 'The quick black cat hissed at the lazy dog'.
+	
+	+ expected
+	- actual
+	
+	-The quick brown fox jumped over the lazy dog
+	+The quick black cat hissed at the lazy dog
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:78:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2357:69
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should show diff when comparing multiline strings FAILED
+	Expected 'The quick brown fox
+	jumped over the lazy dog' to equal 'The quick black cat
+	hissed at the lazy dog'.
+	
+	+ expected
+	- actual
+	
+	-The quick brown fox
+	-jumped over the lazy dog
+	+The quick black cat
+	+hissed at the lazy dog
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:83:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2362:70
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should show diff when comparing arrays FAILED
+	Expected $.length = 3 to equal 4.
+	Expected $[3] = undefined to equal 4.
+	
+	+ expected
+	- actual
+	
+	+  4
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:88:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2367:32
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should show diff when comparing objects FAILED
+	Expected object to have properties
+	    baz: 'baz'
+	Expected object not to have properties
+	    bar: 'bar'
+	
+	+ expected
+	- actual
+	
+	-  'bar': 'bar'
+	+  'baz': 'baz'
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:91:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2370:49
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers toEqual should format values FAILED
+	Expected object to have properties
+	    a: null
+	    b: undefined
+	    c: 1
+	    d: -1
+	    e: 'a'
+	    f: Function
+	    g: /[aeiou]/
+	    h: [  ]
+	    i: [ 1, 2, 3 ]
+	    j: [ [ 1 ], [ 2, 3 ] ]
+	    k: Object({  })
+	    l: Object({ a: 1, b: 2, c: 3 })
+	    m: Object({ a: Object({ b: Object({ c: 1 }) }) })
+	    n: Object({ a: [ Object({ b: true }) ] })
+	
+	+ expected
+	- actual
+	
+	-{}
+	+{
+	+  'a': null
+	+  'b': undefined
+	+  'c': 1
+	+  'd': -1
+	+  'e': 'a'
+	+  'f': Function
+	+  'g': /[aeiou]/
+	+  'h': []
+	+  'i': [
+	+    1
+	+    2
+	+    3
+	+  ]
+	+  'j': [
+	+    [
+	+      1
+	+    ]
+	+    [
+	+      2
+	+      3
+	+    ]
+	+  ]
+	+  'k': {}
+	+  'l': {
+	+    'a': 1
+	+    'b': 2
+	+    'c': 3
+	+  }
+	+  'm': {
+	+    'a': {
+	+      'b': {
+	+        'c': 1
+	+      }
+	+    }
+	+  }
+	+  'n': {
+	+    'a': [
+	+      {
+	+        'b': true
+	+      }
+	+    ]
+	+  }
+	+}
+	
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:111:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2390:29
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers not.toEqual should omit diff when comparing null/undefined FAILED
+	Expected null not to equal null.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:117:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2396:31
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers not.toEqual should omit diff when comparing scalars FAILED
+	Expected 42 not to equal 42.
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:120:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2399:29
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers not.toEqual should show diff when comparing arrays FAILED
+	Expected [ 1, 2, 3 ] not to equal [ 1, 2, 3 ].
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:123:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2402:36
+PhantomJS 2.1.1 (Mac OS X 0.0.0) Jasmine Diff Matchers not.toEqual should show diff when comparing objects FAILED
+	Expected Object({ foo: 'foo', bar: 'bar' }) not to equal Object({ foo: 'foo', bar: 'bar' }).
+	/var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/failure.js:126:0 <- /var/folders/x3/t7h_ctrn0151f51k6nsvtcl40001z4/T/89e0464e73cdbed3366e80b1656c159b.browserify:2405:53
+PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 22 of 22 (20 FAILED) (0.033 secs / 0.02 secs)

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -1,153 +1,33 @@
+const fs = require('fs')
+const path = require('path')
 const spawn = require('cross-spawn')
 const test = require('tape')
 
 test('jasmine diff matchers failure output', t => {
-  const result = spawn.sync('karma', [
-    'start',
-    'test/functional/karma.conf.js'
-  ]).stdout.toString().replace(/\t/g, '        ').replace(/^\s+$/gm, '')
+  t.plan(3)
 
-  t.ok(result.includes('(20 FAILED)'), 'covers expected number of failure cases')
+  function normalizeOutput (str) {
+    return str
+      .replace(/\d+ secs/g, 'XXX secs')
+      .replace(/(Linux|Mac OS X)/g, 'Host OS')
+      .replace(/\/[a-zA-Z0-9_\-/]+\.(js|browserify)/g, '/NORMALIZED_PATH')
+  }
 
-  const numDiffs = result
-    .split('\n')
-    .filter(line => line.includes('+ expected'))
-    .length
-  t.equal(numDiffs, 10, 'selectively displays diff output based on actual/expected values')
+  const tests = [
+    'karma.conf.js',
+    'karma.conf.colors.js',
+    'karma.conf.inline.js'
+  ]
 
-  t.ok(result.includes(`
-        + expected
-        - actual
-
-        -The quick brown fox jumped over the lazy dog
-        +The quick black cat hissed at the lazy dog
-  `.trim()), 'displays diff output for long strings')
-
-  t.ok(result.includes(`
-        + expected
-        - actual
-
-        -The quick brown fox
-        -jumped over the lazy dog
-        +The quick black cat
-        +hissed at the lazy dog
-  `.trim()), 'displays diff output for multiline strings')
-
-  t.ok(result.includes(`
-        Expected $.length = 3 to equal 4.
-        Expected $[3] = undefined to equal 4.
-
-        + expected
-        - actual
-
-        +  4
-  `.trim()), 'displays diff output for arrays')
-
-  t.ok(result.includes(`
-        + expected
-        - actual
-
-        -  'bar': 'bar'
-        +  'baz': 'baz'
-  `.trim()), 'displays diff output for objects')
-
-  t.equal((result.match(/not to equal/g) || []).length, 4, 'omits diffs for .not negations')
-
-  t.ok(result.includes(`
-        + expected
-        - actual
-
-        -{}
-        +{
-        +  'a': null
-        +  'b': undefined
-        +  'c': 1
-        +  'd': -1
-        +  'e': 'a'
-        +  'f': Function
-        +  'g': /[aeiou]/
-        +  'h': []
-        +  'i': [
-        +    1
-        +    2
-        +    3
-        +  ]
-        +  'j': [
-        +    [
-        +      1
-        +    ]
-        +    [
-        +      2
-        +      3
-        +    ]
-        +  ]
-        +  'k': {}
-        +  'l': {
-        +    'a': 1
-        +    'b': 2
-        +    'c': 3
-        +  }
-        +  'm': {
-        +    'a': {
-        +      'b': {
-        +        'c': 1
-        +      }
-        +    }
-        +  }
-        +  'n': {
-        +    'a': [
-        +      {
-        +        'b': true
-        +      }
-        +    ]
-        +  }
-        +}
-  `.trim()), 'properly stringifies values')
-
-  t.end()
-})
-
-test('jasmine diff with colors enabled', t => {
-  const result = spawn.sync('karma', [
-    'start',
-    'test/functional/karma.conf.colors.js'
-  ]).stdout.toString().replace(/\t/g, '        ').replace(/^\s+$/gm, '')
-
-  t.ok(result.includes(`
-        \x1B[32m+ expected\x1B[0m
-        \x1B[31m- actual\x1B[0m
-
-        \x1B[31m-  'bar': 'bar'\x1B[0m
-        \x1B[32m+  'baz': 'baz'\x1B[0m
-  `.trim()), 'displays diff output with color')
-
-  t.end()
-})
-
-test('jasmine diff with inline mode enabled', t => {
-  const result = spawn.sync('karma', [
-    'start',
-    'test/functional/karma.conf.inline.js'
-  ]).stdout.toString().replace(/\t/g, '        ').replace(/^\s+$/gm, '')
-
-  t.ok(result.includes(`
-        \x1B[31mactual\x1B[0m \x1B[32mexpected\x1B[0m
-
-        {
-          'bar': '\x1B[31mbar\x1B[0m\x1B[32mbaz\x1B[0m'
-          'foo': 'foo'
-        }
-  `.trim()), 'displays inline diffs')
-
-  t.ok(result.includes(`
-        \x1B[31mactual\x1B[0m \x1B[32mexpected\x1B[0m
-
-        1 | {
-        2 |   'bar': 'bar'
-        3 |   'baz': '\x1B[31mqux\x1B[0m\x1B[32mbaz\x1B[0m'
-        4 |   'foo': 'foo'
-        5 | }
-  `.trim()), 'shows line numbers when diff exceeds 4 lines')
+  tests.forEach(function (configFilename) {
+    const actual = spawn.sync('karma', [
+      'start',
+      'test/functional/' + configFilename
+    ]).stdout.toString()
+    const expected = fs.readFileSync(path.join(__dirname, 'fixtures', configFilename + '.output'), 'utf8')
+    t.equal(normalizeOutput(actual), normalizeOutput(expected),
+      'output for ' + configFilename + ' matches expected output')
+  })
 
   t.end()
 })

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -34,7 +34,8 @@ test('jasmine diff matchers failure output', t => {
   `.trim()), 'displays diff output for multiline strings')
 
   t.ok(result.includes(`
-        Expected [ 1, 2, 3 ] to equal [ 1, 2, 3, 4 ].
+        Expected $.length = 3 to equal 4.
+        Expected $[3] = undefined to equal 4.
 
         + expected
         - actual
@@ -43,8 +44,6 @@ test('jasmine diff matchers failure output', t => {
   `.trim()), 'displays diff output for arrays')
 
   t.ok(result.includes(`
-        Expected Object({ foo: 'foo', bar: 'bar' }) to equal Object({ foo: 'foo', baz: 'baz' }).
-
         + expected
         - actual
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -230,8 +230,8 @@ test('long, asymmetric, colored, inline diffs', function (t) {
   t.ok(result.message.includes(`
 1 | {
 2 |   'a': 1
-3 | \x1B[31m  'b': 2\x1B[0m
-4 | \x1B[31m  'c': 3\x1B[0m
+3 | \x1B[41m\x1B[37m  'b': 2\x1B[0m\x1B[0m
+4 | \x1B[41m\x1B[37m  'c': 3\x1B[0m\x1B[0m
 5 | }
   `.trim()), 'does not bleed colors into line numbers')
   t.end()


### PR DESCRIPTION
Use background color rather than foreground color when configured with `inline:true, colors:true` so whitespace differences are move obvious.

Fixes #7.