### PR TITLE
Add an option to disable default comparison messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Enables colored diff output.
 
 Display inline diffs (best paired with `colors:true`).
 
+#### `printDefaultMessages` (boolean, default: `true`)
+
+Display the default comparison's failure message before the unified diff.
+Can be set to false to show only the unified diff.
+
 ## Changelog
 
 #### 0.1.3

--- a/index.js
+++ b/index.js
@@ -400,7 +400,8 @@ module.exports = function jasmineDiffMatchers (j$, options) {
   var opts = {
     colors: options && options.colors === true,
     inline: options && options.inline === true,
-    spaces: 2
+    spaces: 2,
+    printDefaultMessages: options ? options.printDefaultMessages : true,
   }
   var annotateAdd = opts.colors ? (opts.inline ? greenBg : green) : identity
   var annotateRemove = opts.colors ? (opts.inline ? redBg : red) : identity
@@ -421,10 +422,13 @@ module.exports = function jasmineDiffMatchers (j$, options) {
             return result
           }
 
-          result.message = (result.message || defaultMessage(actual, expected, desc)) +
-            '\n\n' + errorDiff(stringify(actual), stringify(expected), annotateAdd, annotateRemove) + '\n'
+          var defaultMessage = opts.printDefaultMessages ?
+              (result.message || defaultMessage(actual, expected, desc)) + '\n\n' : '';
+          result.message = defaultMessage
+              + errorDiff(stringify(actual), stringify(expected), annotateAdd, annotateRemove)
+              + '\n'
 
-          return result
+          return result;
         }
       }
     }


### PR DESCRIPTION
This PR adds an option that effectively only prints out the unified diffs. This is very useful when there are small changes to large arrays.